### PR TITLE
docs: suggest npx build-agent-app@latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 Build custom AI agents with the Claude Agent SDK or OpenAI Agents SDK. Choose your approach:
 
 - **[Web UI](./agent-workshop-app)** - Visual builder with live code preview
-- **[CLI](./create-agent-app)** - Interactive terminal wizard (`npx build-agent-app`)
+- **[CLI](./create-agent-app)** - Interactive terminal wizard (`npx build-agent-app`) — or run without installing: `npx build-agent-app@latest`
 
 ## Quick Start
 
 ### CLI (Recommended)
 
 ```bash
-npx build-agent-app my-agent
+npx build-agent-app@latest my-agent
 cd my-agent
 cp .env.example .env  # Add your API key
 npm run build

--- a/create-agent-app/README.md
+++ b/create-agent-app/README.md
@@ -9,7 +9,7 @@ Create AI agents with the Claude Agent SDK or OpenAI Agents SDK.
 ## Quick Start
 
 ```bash
-npx build-agent-app my-agent
+npx build-agent-app@latest my-agent
 cd my-agent
 cp .env.example .env  # Add your API key
 npm run build


### PR DESCRIPTION
Small docs tweak: recommend using `npx build-agent-app@latest` in Quick Start so users always run the latest published CLI, and mention it in the top-level README.